### PR TITLE
[WFCORE-4296][WFCORE-5406] Tweaks for Windows scripts

### DIFF
--- a/core-feature-pack/common/src/main/resources/content/bin/common.bat
+++ b/core-feature-pack/common/src/main/resources/content/bin/common.bat
@@ -18,7 +18,7 @@ endlocal
 goto :eof
 
 :setPackageAvailable
-    "%JAVA%" --add-opens=$1=ALL-UNNAMED -version >nul 2>&1 && (set PACKAGE_AVAILABLE=true) || (set PACKAGE_AVAILABLE=false)
+    "%JAVA%" --add-opens=%~1=ALL-UNNAMED -version >nul 2>&1 && (set PACKAGE_AVAILABLE=true) || (set PACKAGE_AVAILABLE=false)
 goto :eof
 
 :setEnhancedSecurityManager
@@ -54,9 +54,9 @@ goto :eof
       set "DEFAULT_MODULAR_JVM_OPTIONS=!DEFAULT_MODULAR_JVM_OPTIONS! --add-exports=jdk.naming.dns/com.sun.jndi.dns=ALL-UNNAMED"
       rem Needed by WildFly Elytron Extension
       set PACKAGE_NAME="java.base/com.sun.net.ssl.internal.ssl"
-      call :setPackageAvailable %PACKAGE_NAME%
-      if "!$PACKAGE_AVAILABLE!" == "true" (
-        set "DEFAULT_MODULAR_JVM_OPTIONS=!DEFAULT_MODULAR_JVM_OPTIONS! --add-opens=%PACKAGE_NAME%=ALL-UNNAMED"
+      call :setPackageAvailable !PACKAGE_NAME!
+      if "!PACKAGE_AVAILABLE!" == "true" (
+        set "DEFAULT_MODULAR_JVM_OPTIONS=!DEFAULT_MODULAR_JVM_OPTIONS! --add-opens=!PACKAGE_NAME!=ALL-UNNAMED"
       )
       rem Needed if Hibernate applications use Javassist
       set "DEFAULT_MODULAR_JVM_OPTIONS=!DEFAULT_MODULAR_JVM_OPTIONS! --add-opens=java.base/java.lang=ALL-UNNAMED"

--- a/core-feature-pack/common/src/main/resources/content/bin/common.ps1
+++ b/core-feature-pack/common/src/main/resources/content/bin/common.ps1
@@ -185,8 +185,8 @@ Param(
         $DEFAULT_MODULAR_JVM_OPTIONS += "--add-exports=jdk.naming.dns/com.sun.jndi.dns=ALL-UNNAMED"
         # Needed by WildFly Elytron Extension
         $packageName = "java.base/com.sun.net.ssl.internal.ssl"
-        setPackageAvailable($packageName)
-        if($PACKAGE_AVAILABLE -eq 'true') {
+        $PACKAGE_AVAILABLE = setPackageAvailable($packageName)
+        if($PACKAGE_AVAILABLE) {
             $DEFAULT_MODULAR_JVM_OPTIONS += "--add-opens=$packageName=ALL-UNNAMED"
         }
         # Needed if Hibernate applications use Javassist


### PR DESCRIPTION
Some tweaks for Windows:

* Add `~` for the parameter using in function, like:  `%~1` for the first parameter, `%~2` for the second one, etc, batch script does not use `$`
* Replace `%PACKAGE_NAME%` with `!PACKAGE_NAME!` in the power shell script

I tested in my local Windows machine, and both `standalone.bat` and `standalone.ps1` can start correctly.